### PR TITLE
Some proposed enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.idea/

--- a/flogger.html
+++ b/flogger.html
@@ -6,6 +6,7 @@
 			logname: {value:"",required:true},
 			logdir: {value:"",required:true},
 			stamp: {value:"utc"},
+            stampFormat: {value:"YYYY/MM/DD HH:mm:ss"},
 			logstyle: {value:"plain"},
 			logrotate: {value:""},
 			logcompress: {value:""},
@@ -59,6 +60,10 @@
 			<option value="utc">UTC</option>
 			<option value="local">Local</option>
 		</select>
+	</div>
+	<div class="form-row">
+	    <label for="node-config-input-stampFormat"><i class="fa fa-clock-o"></i> Timestamp Format</label>
+		<input type="text" id="node-config-input-stampFormat">
 	</div>
 	<div class="form-row">
 		<label for="node-config-input-logstyle"><i class="fa fa-clock-o"></i> Log Style</label>

--- a/flogger.html
+++ b/flogger.html
@@ -10,7 +10,9 @@
 			logrotate: {value:""},
 			logcompress: {value:""},
 			logrotatecount: {value: "5"},
-			logsize: {value: "1000"}
+			logsize: {value: "1000"},
+			logtopic: {value: ""},
+			logsource: {value: "1"},
 		},
 		label: function() {
 			return this.logname
@@ -23,6 +25,14 @@
       				$("#node-config-rotate-row").hide()
       			}
 			})
+
+			$("#node-config-input-logstyle").change(function() {
+                        	if ($(this).val() == "plain") {
+                                	$("#node-config-plain-row").show()
+                        	} else {
+					$("#node-config-plain-row").hide()
+                        	}
+                	})
 		},
 		oneditsave: function() {
 			if ($("#node-config-input-logrotate").is(':checked')) {
@@ -56,6 +66,16 @@
 			<option value="plain">Plain Text</option>
 			<option value="json">Pure JSON</option>
 		</select>
+	</div>
+	<div class="node-config-plain-row">
+		<div class="form-row">
+			<label style="width: auto; margin-left: 20px; margin-right: 10px;" for="node-config-input-logtopic"><i class="fa fa-chevron-right"></i> Incl topic</label>
+			<input type="checkbox" id="node-config-input-logtopic" style="display: inline-block; width: auto; vertical-align: top;">
+		</div>
+		<div class="form-row">
+			<label style="width: auto; margin-left: 20px; margin-right: 10px;" for="node-config-input-logsource"><i class="fa fa-chevron-right"></i> Incl source</label>
+			<input type="checkbox" id="node-config-input-logsource" style="display: inline-block; width: auto; vertical-align: top;">
+		</div>
 	</div>
 	<div class="form-row">
 		<label for="node-config-input-logrotate"><i class="fa fa-repeat"></i> Rotate</label>
@@ -93,7 +113,7 @@
 			inputobject: {value:"payload"},
 			inputobjectType: {value: 'msg'},
 			inputmoustache: {value: 'Recieved payload {{payload}} and topic {{topic}}'},
-			loglevel: {value:"INFO", required: true},
+			loglevel: {value:"INFO", required: false},
 			logconfig: {type:"config-log"},
 			sendpane: {value:""},
 		},
@@ -156,6 +176,7 @@
 	<div class="form-row">
 		<label for="node-input-loglevel"><i class="fa fa-exclamation"></i> Level</label>
 		<select type="text" id="node-input-loglevel" placeholder="Log Level">
+			<option value="">(None)</option>
 			<option value="ERROR">ERROR</option>
 			<option value="WARN">WARN</option>
 			<option value="INFO">INFO</option>

--- a/flogger.html
+++ b/flogger.html
@@ -241,7 +241,9 @@
 	<p>In the <code>Timestamp</code> dropdown you can choose if you want to stamp each log line with
 	either UTC time, local time or no time at all</p>
 	<p>In the <code>Log Style</code> dropdown you can choose if you want a normal plain logfile similar
-	to syslog, or if you want a json logfile similar to NLOG</p>
+	to syslog, or if you want a json logfile similar to NLOG. If plain, 2 more options are shown:</p>
+	<p><code>Incl topic</code> Include msg.topic in the log if it exist</p>
+	<p><code>Incl source</code> Include the source of the message such as "msg.payload".</p>
 	<p>Check <code>Rotate</code> If you want to do automatic log rotation. If checked 3 more options
 	are shown:</p>
 	<p><code>Compress</code> Each rotated logfile will be gzip compressed if checked</p>

--- a/flogger.js
+++ b/flogger.js
@@ -32,11 +32,18 @@ module.exports = function(RED) {
 			}
 
 			if (node.logconfig.logstyle == "plain") {
-				if (node.logconfig.stamp == "none") {
-					logline = loglevel + " [" + logmessage.var + "] " + logmessage.msg + "\n"
-				} else {
-					logline = logTimeStamp + " " + loglevel + " [" + logmessage.var + "] " + logmessage.msg + "\n"
-				}
+				timeStamp = (node.logconfig.stamp === 'none' ? '' : logTimeStamp + ' ')
+				level = (loglevel === '' ? '' : loglevel + ' ')
+				topic = (node.logconfig.logtopic === true && msg.topic ? msg.topic : '')
+				source = (node.logconfig.logsource === true ? logmessage.var : '')
+				topicOrSource = (topic !== '' || source !== '')
+				topicAndSource = (topic !== '' && source !== '')
+				bracket1 = (topicOrSource ? '[' : '')
+				bracket2 = (topicOrSource ? '] ' : '')
+				separator = (topicAndSource ? ':' : '')
+
+				logline = timeStamp + level + bracket1 + topic + separator + source + bracket2 + logmessage.msg + '\n'
+
 			} else {
 				logline = GetJSONMsg(logTimeStamp, loglevel, logmessage.var, logmessage.raw)
 			}
@@ -45,19 +52,21 @@ module.exports = function(RED) {
 			if (msg.logfile) logfile = msg.logfile // logfile override via msg object if provided
 			LogRotate(node, logfile, logline.length)
 			WriteMsgToFile(node, logfile, logline, logTimeStamp)
-			
+
 			node.send(msg); // pass through original message
 		})
 	}
 
 	RED.nodes.registerType("flogger",FloggerNode)
-	
+
 	function FloggerConfigNode(n) {
 		RED.nodes.createNode(this,n)
 		this.logdir = n.logdir
 		this.logname = n.logname
 		this.stamp = n.stamp
 		this.logstyle = n.logstyle
+		this.logtopic = n.logtopic
+		this.logsource = n.logsource
 
 		this.logrotate = n.logrotate
 		this.logcompress = n.logcompress

--- a/flogger.js
+++ b/flogger.js
@@ -50,7 +50,7 @@ module.exports = function(RED) {
 
 			logfile = node.logfile
 			if (msg.logfile) logfile = msg.logfile // logfile override via msg object if provided
-			LogRotate(node, logfile, logline.length)
+			LogRotate(node, logfile, logline.length, msg.rotateNow)
 			WriteMsgToFile(node, logfile, logline, logTimeStamp)
 
 			node.send(msg); // pass through original message
@@ -195,13 +195,13 @@ module.exports = function(RED) {
 	There will be maximum node.logconfig.rotatecount files in the directory.
 	If compression is set in node.logconfig.compress then the rotated files will be gzipped
 	*/
-	function LogRotate(node, filename, addlength) {
+	function LogRotate(node, filename, addlength, rotateNow) {
 		if (node.logconfig.logrotate && filename) {
 			fullpath = node.logconfig.logdir + "/" + filename
 			if (fs.existsSync(fullpath)) {
 				stats = fs.statSync(fullpath)
 				fileSizeInBytes = stats["size"]
-				if (fileSizeInBytes + addlength + 1 >= node.logconfig.logsize * 1000 ) {
+				if ((rotateNow === true) || (fileSizeInBytes + addlength + 1 >= node.logconfig.logsize * 1000 )) {
 					rotate(fullpath, { count: node.logconfig.logrotatecount, compress: (node.logconfig.logcompress==true)}, function(err) {
 						if (err) {
 							node.warn("Could not rotate logfiles: " + err)

--- a/flogger.js
+++ b/flogger.js
@@ -64,6 +64,7 @@ module.exports = function(RED) {
 		this.logdir = n.logdir
 		this.logname = n.logname
 		this.stamp = n.stamp
+		this.stampFormat = n.stampFormat;
 		this.logstyle = n.logstyle
 		this.logtopic = n.logtopic
 		this.logsource = n.logsource
@@ -153,13 +154,14 @@ module.exports = function(RED) {
 	Allowed time formats: none, utc, local 
 	*/
 	function GetLogTime(node) {
-		now = new Date()
+		now = new Date();
+		const format = node.logconfig.stampFormat||"YYYY/MM/DD HH:mm:ss";
 		if (node.logconfig.stamp == "none") {
 			logtime = ""
 		} else if (node.logconfig.stamp == "utc") {
-			logtime = moment(now).utc().format("YYYY/MM/DD HH:mm:ss") + "Z"
+			logtime = moment(now).utc().format(format) + "Z"
 		} else if (node.logconfig.stamp == "local") {	
-			logtime = moment(now).parseZone().local().format("YYYY/MM/DD HH:mm:ss")
+			logtime = moment(now).parseZone().local().format(format)
 		}
 		return (logtime)
 	}


### PR DESCRIPTION
Hello Alex - not sure if you're interested in other contributors, but I wanted a couple of options myself, so thought I'd give it a bash. 

The changes I'm proposing are:

1. Allowing log level to be optional by including a "(none)" option.
2. Allowing `msg.topic` to be included in the log if present. This is set up in the `log-config` page when the log style is plain text. This defaults to unselected for backward compatibility.
3. Allowing the source (eg. `msg.payload`) to be optional. This is also set up in the `log-config` page when the log style is plain text. I think this should be backwardly compatible, because it's defaulting to selected.
4. If both topic and source are included, they're separated by a ":".

What do you think?