### PR TITLE
fix: Ensure proper JSON formatting for log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,7 @@ Logrotation with/without compression can be enabled.
 
 **Example output ~/logs/logfile2:**
 
-    {"time":"2019/07/15 16:46:46","level":"DEBUG","var":"msg.payload","message":1563202006292}
-	{"time":"2019/07/15 16:46:51","level":"DEBUG","var":"msg.payload","message":1563202011877}
+    [
+        {"time":"2019/07/15 16:46:46","level":"DEBUG","var":"msg.payload","message":1563202006292},
+	    {"time":"2019/07/15 16:46:51","level":"DEBUG","var":"msg.payload","message":1563202011877}
+    ]


### PR DESCRIPTION
The reason for this change is to address situations where JSON-formatted logs were not being written to the file in a proper JSON format. The modified function is designed to tackle this issue by introducing the "logstyle" property. If "logstyle" is set to JSON, the data is first appended to a JSON array, ensuring that this array adheres to a proper JSON format, and then the updated JSON array is written to the file. This improvement ensures that logs in JSON format are stored in a more structured and readable manner.